### PR TITLE
Explicit dependencies declarations for spring-boot-configmap booster.…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,10 @@
     <version.com.fasterxml.jackson.module.jackson-module-jaxb-annotations>2.8.3</version.com.fasterxml.jackson.module.jackson-module-jaxb-annotations>
     <version.commons-codec.commons-codec>1.10</version.commons-codec.commons-codec>
     <version.com.h2database.h2>1.4.192</version.com.h2database.h2>
-    <version.io.fabric8.kubernetes-client>2.2.14</version.io.fabric8.kubernetes-client>
-    <version.io.fabric8.openshift-client>2.2.14</version.io.fabric8.openshift-client>
-    <version.io.fabric8.spring-cloud-kubernetes-core>0.1.6</version.io.fabric8.spring-cloud-kubernetes-core>
-    <version.io.fabric8.spring-cloud-starter-kubernetes-netflix>0.1.6</version.io.fabric8.spring-cloud-starter-kubernetes-netflix>
+    <version.io.fabric8.kubernetes-client>1.4.34</version.io.fabric8.kubernetes-client>
+    <version.io.fabric8.openshift-client>1.4.34</version.io.fabric8.openshift-client>
+    <version.io.fabric8.spring-cloud-kubernetes-core>0.1.4</version.io.fabric8.spring-cloud-kubernetes-core>
+    <version.io.fabric8.spring-cloud-starter-kubernetes-netflix>0.1.4</version.io.fabric8.spring-cloud-starter-kubernetes-netflix>
     <version.javax.servlet.jstl>1.2</version.javax.servlet.jstl>
     <version.mysql.mysql-connector-java>5.1.39</version.mysql.mysql-connector-java>
     <version.org.apache.cxf.cxf-spring-boot-starter-jaxrs>3.1.10</version.org.apache.cxf.cxf-spring-boot-starter-jaxrs>
@@ -61,6 +61,7 @@
     <version.org.apache.tomcat.embed.tomcat-embed-el>8.0.36</version.org.apache.tomcat.embed.tomcat-embed-el>
     <version.org.apache.tomcat.embed.tomcat-embed-jasper>8.0.36</version.org.apache.tomcat.embed.tomcat-embed-jasper>
     <version.org.apache.tomcat.embed.tomcat-embed-websocket>8.0.36</version.org.apache.tomcat.embed.tomcat-embed-websocket>
+    <version.org.apache.tomcat.tomcat-juli>8.0.36</version.org.apache.tomcat.tomcat-juli>
     <version.org.codehaus.groovy.groovy>2.4.7</version.org.codehaus.groovy.groovy>
     <version.org.codehaus.groovy.groovy-json>2.4.7</version.org.codehaus.groovy.groovy-json>
     <version.org.codehaus.groovy.groovy-xml>2.4.7</version.org.codehaus.groovy.groovy-xml>
@@ -68,6 +69,7 @@
     <version.org.javassist.javassist>3.20.0-GA</version.org.javassist.javassist>
     <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
     <version.org.json.json>20140107</version.org.json.json>
+    <version.org.slf4j.jul-to-slf4j>1.7.21</version.org.slf4j.jul-to-slf4j>
     <version.org.slf4j.slf4j-api>1.7.21</version.org.slf4j.slf4j-api>
     <version.org.springframework.boot.spring-boot>1.4.1.RELEASE</version.org.springframework.boot.spring-boot>
     <version.org.springframework.cloud.spring-cloud-netflix>1.1.6.RELEASE</version.org.springframework.cloud.spring-cloud-netflix>
@@ -76,6 +78,7 @@
     <version.org.springframework.spring-orm>4.3.3.RELEASE</version.org.springframework.spring-orm>
     <version.org.springframework.spring-tx>4.3.3.RELEASE</version.org.springframework.spring-tx>
     <version.org.springframework.spring-web>4.3.3.RELEASE</version.org.springframework.spring-web>
+    <version.org.springframework.security.spring-security-crypto>4.1.3.RELEASE</version.org.springframework.security.spring-security-crypto>
     <version.xml-apis.xml-apis>1.4.01</version.xml-apis.xml-apis>
   </properties>
 
@@ -246,6 +249,11 @@
         <artifactId>spring-web</artifactId>
         <version>${version.org.springframework.spring-web}</version>
       </dependency>
+      <dependency>
+        <groupId>org.springframework.security</groupId>
+        <artifactId>spring-security-crypto</artifactId>
+        <version>${version.org.springframework.security.spring-security-crypto}</version>
+      </dependency>
 
       <dependency>
         <groupId>com.fasterxml</groupId>
@@ -365,6 +373,11 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
+        <artifactId>jul-to-slf4j</artifactId>
+        <version>${version.org.slf4j.jul-to-slf4j}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
         <version>${version.org.slf4j.slf4j-api}</version>
       </dependency>
@@ -411,6 +424,11 @@
         <groupId>org.apache.tomcat.embed</groupId>
         <artifactId>tomcat-embed-websocket</artifactId>
         <version>${version.org.apache.tomcat.embed.tomcat-embed-websocket}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-juli</artifactId>
+        <version>${version.org.apache.tomcat.tomcat-juli}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
… Fixed upstream tomcat version back to 8.5.4 as 8.0.36 throws ClassNotFound exception.

Currently, we use kubernetes-client 1.4.34 compatible implementation, see [https://github.com/snowdrop/spring-boot-parent/issues/2](https://github.com/snowdrop/spring-boot-parent/issues/2)